### PR TITLE
add stories but only show story date if present

### DIFF
--- a/content/stories/2020-11-17-transparency-an-implementers-story.md
+++ b/content/stories/2020-11-17-transparency-an-implementers-story.md
@@ -1,9 +1,8 @@
 ---
-url: /transparency-an-implementers-story
-layout: markdown
+url: /stories/transparency-an-implementers-story
 title: "Transparency: An Implementer's Story"
+show_side_bar: true
 author: "Martin Hutchinson"
-date: 2020-11-17
 ---
 
 Aether’s team is responsible for running a binary download service. Naming is hard, so their service is simply called DownloadServer. Their service has some guarantees that the binary has not been tampered with, by validating a checksum on the client before any binaries are installed. Aether has a concern that this only mitigates some errors and threat models. If their download servers provide a different binary to some users along with a valid checksum then these clients could install malicious software without detection.

--- a/content/stories/_index.md
+++ b/content/stories/_index.md
@@ -1,0 +1,3 @@
+---
+title: "Stories"
+---

--- a/data/claimant_model_docs.json
+++ b/data/claimant_model_docs.json
@@ -13,7 +13,7 @@
     {
       "title": "Transparency, The Implementer’s Story",
       "description": "A story of how an engineer working on a download server uses The Claimant model to implement a transparent, verifiable-log.",
-      "url": "/transparency-an-implementers-story"
+      "url": "/stories/transparency-an-implementers-story"
     }
   ]
 }

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -31,13 +31,15 @@
     <li class="text-right inline mr-6"><a href='{{ "/how-to-design-a-verifiable-system/" | relURL }}' class="text-Grey-600 hover:no-underline">Verifiable Design</a></li>
     <li class="text-right inline mr-6"><a href='{{ "/#trillian" | relURL }}' class="text-Grey-600 hover:no-underline">Trillian</a></li>
     <li class="text-right inline mr-6"><a href='{{ "/verifiable-data-structures/" | relURL }}' class="text-Grey-600 hover:no-underline">Verifiable Data Structures</a></li>
+    <li class="text-right inline mr-6"><a href='{{ "/stories/" | relURL }}' class="text-Grey-600 hover:no-underline">Stories</a></li>
   </ul>
 </nav>
 <ul id="mobileMenu" class="hidden bg-white p-8 fixed w-full z-50">
   <li class="gmb-2"><a href='{{ "/#applications" | relURL }}' class="text-Grey-600 hover:no-underline">Applications</a></li>
   <li class="gmb-2"><a href='{{ "/how-to-design-a-verifiable-system/" | relURL }}' class="text-Grey-600 hover:no-underline">Verifiable Design</a></li>
   <li class="gmb-2"><a href='{{ "/#trillian" | relURL }}' class="text-Grey-600 hover:no-underline">Trillian</a></li>
-  <li class=""><a href='{{ "/verifiable-data-structures/" | relURL }}' class="text-Grey-600 hover:no-underline">Verifiable Data Structures</a></li>
+  <li class="gmb-2"><a href='{{ "/verifiable-data-structures/" | relURL }}' class="text-Grey-600 hover:no-underline">Verifiable Data Structures</a></li>
+  <li class=""><a href='{{ "/stories/" | relURL }}' class="text-Grey-600 hover:no-underline">Stories</a></li>
 </ul>
 </div>
 <div id="nav-spacer" class="h-16"></div>

--- a/layouts/stories/section.html
+++ b/layouts/stories/section.html
@@ -14,7 +14,9 @@
         <ul>
             {{ range .Pages }}
             <h2><a href="{{ relURL .URL }}">{{ .Title }}</a></h2>
-                Published {{ .Date.Format "Monday 2 Jan 2006" }}
+              {{ if .Date }}
+                <p>Published {{ .Date.Format "Monday 2 Jan 2006" }}</p>
+              {{ end }}
             {{ end }}
         </ul>
     </div>

--- a/layouts/stories/section.html
+++ b/layouts/stories/section.html
@@ -1,0 +1,23 @@
+{{ define "title"}}{{ .Title }}{{ end }}
+{{ define "main"}}
+<div class="glue-page gmt-6 gmb-4 markdown">
+  <div class="glue-grid">
+    <div class="col-span-4 sm:col-span-12 md:col-span-10 md:col-start-2">
+      <h1 class="headline2 sm:text-center gmb-5">
+        <div class="eyebrow">{{ .Params.eyebrow }}</div>
+        {{ .Title }}
+      </h1>
+    </div>
+  </div>
+  <div class="glue-grid">
+    <div class="col-span-4 md:col-span-8 lg:col-start-3 lg:col-span-8 gmb-7 markdown">
+        <ul>
+            {{ range .Pages }}
+            <h2><a href="{{ relURL .URL }}">{{ .Title }}</a></h2>
+                Published {{ .Date.Format "Monday 2 Jan 2006" }}
+            {{ end }}
+        </ul>
+    </div>
+  </div>
+</div>
+{{end}}

--- a/layouts/stories/single.html
+++ b/layouts/stories/single.html
@@ -1,0 +1,32 @@
+{{ define "main"}}
+<div class="glue-page gmt-6 gmb-4 markdown">
+  <div class="glue-grid">
+    <div class="col-span-4 sm:col-span-12 md:col-span-10 md:col-start-2">
+      <h1 class="headline2 md:text-center mb-5 md:mb-16">
+        <div class="eyebrow">{{ .Params.eyebrow }}</div>
+        {{ .Title }}
+      </h1>
+    </div>
+  </div>
+  <div class="glue-grid">
+    <aside class="submenu col-span-4 sm:col-span-6 md:col-span-4 lg:col-span-3 gmb-3">
+      {{ if .Params.show_table_of_contents }}
+        {{ .TableOfContents }}
+      {{ end }}
+      {{ if .Params.author }}
+        <p class="font-bold">
+          {{ .Params.author }}
+        </p>
+      {{ end }}
+      {{ if .Params.Date }}
+        <p class="text-sm">
+          Published {{ .Date.Format "Monday 2 Jan 2006" }}
+        </p>
+      {{ end }}
+    </aside>
+    <article id="content" class="col-span-4 sm:col-span-12 md:col-span-8 lg:col-span-6 gmb-7 markdown">
+      {{ .Content }}
+    </article>
+  </div>
+</div>
+{{end}}


### PR DESCRIPTION
This hides the date from both the `/stories` index page and the actual story page's sidebar.

I had to revert the 'remove stories' commit, as the actual code change was made on `layouts/stories/section.html`