### PR TITLE
Fix HTML bug in update-claimant-model-links

### DIFF
--- a/content/how-to-design-a-verifiable-system.html
+++ b/content/how-to-design-a-verifiable-system.html
@@ -126,7 +126,7 @@ description: How to identify what’s important for you to log and who will veri
       </ul>
 
       <p class="hidden sm:block gmt-4">
-        <a href="{{< rel "/pdfs/claimant-model-tutorial.pdf" >}} class="btn bg-Blue-600 text-white hover:shadow-md inline-flex px-8 items-center justify-center">
+        <a href="{{< rel "/pdfs/claimant-model-tutorial.pdf" >}}" class="btn bg-Blue-600 text-white hover:shadow-md inline-flex px-8 items-center justify-center">
           Start the exercise
         </a>
       </p>


### PR DESCRIPTION
Missing HTML closing `"` in template was causing rendering issues.

Did not present locally when using the Hugo serve command... 🤔