### PR TITLE
Add CODEOWNERS with default team assignment

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*	@google/trillian-team


### PR DESCRIPTION
This enables automatic reviewer assignment for new PRs.