### PR TITLE
Update actions/checkout from master to v3

### DIFF
--- a/.github/workflows/gh-pages-dry-run.yml
+++ b/.github/workflows/gh-pages-dry-run.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v2

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - name: Setup Hugo
       uses: peaceiris/actions-hugo@v2


### PR DESCRIPTION
The actions/checkout version is updated to v3 to be consistent with the version of other GitHub actions.