### PR TITLE
Fix deprecated Page.URL warning

### DIFF
--- a/layouts/articles/section.html
+++ b/layouts/articles/section.html
@@ -13,7 +13,7 @@
     <div class="col-span-4 md:col-span-8 lg:col-start-3 lg:col-span-8 gmb-7 markdown">
         <ul>
             {{ range .Pages }}
-            <h2><a href="{{ relURL .URL }}">{{ .Title }}</a></h2>
+            <h2><a href="{{ relURL .RelPermalink }}">{{ .Title }}</a></h2>
               {{ if .Date }}
                 <p>Published {{ .Date.Format "Monday 2 Jan 2006" }}</p>
               {{ end }}


### PR DESCRIPTION
The warning message can be found in the [dry-run-build job log](https://github.com/google/trillian-website/actions/runs/4545364748/jobs/8012591418) of #34. It will become an error and block the build job after executing `npm audit fix`.

```
WARN 2023/03/28 16:23:19 Page.URL is deprecated and will be removed in a future release. Use .Permalink or .RelPermalink. If what you want is the front matter URL value, use .Params.url
```