### PR TITLE
Add dedicated page for slack invite link

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -54,7 +54,7 @@ description: Build tamper-evident services with Trillian and cryptographically p
         Welcome to Transparency.dev, a community dedicated to promoting transparency across various ecosystems and pioneering its integration into new application domains.
       </p>
       <p class="gmb-2 headline5 intro-para">
-        Get started by joining our <a href="https://join.slack.com/t/transparency-dev/shared_invite/zt-2jt6643n4-I5wLUo90_tvTVd4nfmfDug">Slack Channel <nobr>
+        Get started by joining our <a href="{{< relref "/slack" >}}">Slack Channel <nobr>
           {{< top-right-arrow >}}</nobr></a> 
       </p>
       <p class="gmb-4 headline5 intro-para">

--- a/content/slack.html
+++ b/content/slack.html
@@ -1,0 +1,21 @@
+---
+url: /slack
+layout: index
+title: Transparency.dev Slack
+description: Invite link to the transparency.dev slack
+---
+<section class="glue-page gmt-6 gmb-7">
+  <h1 class="headline2 sm:text-center gmb-4">
+    Transparency.dev Slack
+  </h1>
+
+  <p class="headline5 sm:text-center gmb-3">
+    Join the transparency.dev community slack now!
+  </p>
+
+  <p class="sm:text-center">
+    <a href="https://join.slack.com/t/transparency-dev/shared_invite/zt-2jt6643n4-I5wLUo90_tvTVd4nfmfDug" class="btn bg-Blue-600 text-white hover:shadow-md inline-flex px-8 items-center justify-center">
+      Slack invite
+    </a>
+  </p>
+</section>


### PR DESCRIPTION
All locations that invite people to join the transparency.dev slack
should link to this page.  That way, if the invite link expires, it only
has to be updated here for all links to be correct again.
