### PR TITLE
Remove all Trillian content from the t.dev home page

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -2,7 +2,7 @@
 url: /index
 layout: index
 title: An open-source append only ledger
-description: Build tamper-evident services with Trillian and cryptographically prove that the data hasn’t been unexpectedly changed.
+description: Build tamper-evident services and cryptographically prove that the data hasn’t been unexpectedly changed.
 ---
 
 <section class="glue-page gpt-7 gpb-7">
@@ -266,6 +266,7 @@ description: Build tamper-evident services with Trillian and cryptographically p
   </div>
 </section>
 
+<!--
 <div class="bg-Grey-050">
   <a id="trillian"></a>
   <section class="glue-page gpt-6 gpb-6">
@@ -332,21 +333,6 @@ description: Build tamper-evident services with Trillian and cryptographically p
   </div>
 </section>
 
-<!-- Get started block -->
-<!--
-<section class="glue-page gmt-7 gmb-6">
-  <div class="glue-grid">
-    <div class="col-span-4 sm:col-span-10 sm:col-start-2 markdown">
-      <h2 class="headline3 gmt-4 gpb-4 sm:text-center" style="margin-bottom: 0;">Installing Trillian</h2>
-      {{< read-markdown-file "/content/get-started.md" >}}
-
-      <div class="gpt-3">
-        {{< trillian-youtube 1Yfb4uSlFTM >}}
-      </div>
-    </div>
-  </div>
-</section>
--->
 
 <a id="why"></a>
 <section class="glue-page gmt-6 gmb-6">
@@ -400,6 +386,7 @@ description: Build tamper-evident services with Trillian and cryptographically p
     </a>
   </p>
 </section>
+-->
 
 <script>
   'use strict';

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -25,9 +25,6 @@
             <a href='{{ "/#benefits" | relURL }}' class="text-Grey-600 hover:text-Grey-900 hover:no-underline">Benefits of tamper-evident logs</a>
           </li>
           <li>
-            <a href='{{ "/#trillian" | relURL }}' class="text-Grey-600 hover:text-Grey-900 hover:no-underline">Trillian: an open-source verifiable log</a>
-          </li>
-          <li>
             <a href='{{ "/verifiable-data-structures/" | relURL }}' class="text-Grey-600 hover:text-Grey-900 hover:no-underline">Verifiable Data Structures</a>
           </li>
         </ul>


### PR DESCRIPTION
Commented out for now in case we want to re-use some of it for Tessera.
Clean up where it's removed completely to follow.
