### PR TITLE
Bump GitHub Actions and Node.js version to 24 in workflows

### DIFF
--- a/.github/workflows/gh-pages-dry-run.yml
+++ b/.github/workflows/gh-pages-dry-run.yml
@@ -21,21 +21,21 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
         hugo-version: '0.83.1'
         extended: true
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
-        node-version: 18
+        node-version: 24
 
     - name: Cache node modules
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: node_modules
         key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,21 +24,21 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Setup Hugo
-      uses: peaceiris/actions-hugo@v2
+      uses: peaceiris/actions-hugo@v3
       with:
         hugo-version: '0.83.1'
         extended: true
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
-        node-version: 18
+        node-version: 24
 
     - name: Cache node modules
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: node_modules
         key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
The recent deployments to GH pages were failed. This PR tries to fix this by bumping the versions of GH Actions.

https://github.com/google/trillian-website/actions/runs/28663243852